### PR TITLE
Add ability to edit colors from the theme.

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -50,6 +50,8 @@
     "@types/jest": "^26.0.21",
     "@types/node": "^14.14.35",
     "@types/react": "^17.0.3",
+    "@types/react-redux": "^7.1.16",
+    "@types/styled-components": "^5.1.9",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",

--- a/editor/src/components/inputs/color.js
+++ b/editor/src/components/inputs/color.js
@@ -4,7 +4,7 @@ import { TextInputField } from 'evergreen-ui';
 import PropTypes from 'prop-types';
 import { isValidCSSColor } from '../../util/is-valid-css-color';
 
-const Container = styled.div`
+export const Container = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/editor/src/components/inspector/document-inspector.js
+++ b/editor/src/components/inspector/document-inspector.js
@@ -1,51 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
 import { Pane } from './inspector-styles';
-import { deckSlice, themeSelector } from '../../slices/deck-slice';
-import { ColorPickerInput } from '../inputs/color';
+import { ThemeValues } from './theme-values';
 
 export const DocumentInspector = () => {
-  const dispatch = useDispatch();
-  const theme = useSelector(themeSelector);
-  const [primaryColor, setPrimaryColor] = useState('');
-  const [secondaryColor, setSecondaryColor] = useState('');
-  const [tertiaryColor, setTertiaryColor] = useState('');
-
-  useEffect(() => {
-    setPrimaryColor(theme?.colors?.primary || '');
-    setSecondaryColor(theme?.colors?.secondary || '');
-    setTertiaryColor(theme?.colors?.tertiary || '');
-  }, [theme]);
-
   return (
     <Pane>
-      <ColorPickerInput
-        onChangeInput={setPrimaryColor}
-        label="Primary Theme Value"
-        onUpdateValue={(value) =>
-          dispatch(deckSlice.actions.updateThemeColors({ primary: value }))
-        }
-        validValue={theme?.colors?.primary}
-        value={primaryColor}
-      />
-      <ColorPickerInput
-        onChangeInput={setSecondaryColor}
-        label="Secondary Theme Value"
-        onUpdateValue={(value) =>
-          dispatch(deckSlice.actions.updateThemeColors({ secondary: value }))
-        }
-        validValue={theme?.colors?.secondary}
-        value={secondaryColor}
-      />
-      <ColorPickerInput
-        onChangeInput={setTertiaryColor}
-        label="Tertiary Theme Value"
-        onUpdateValue={(value) =>
-          dispatch(deckSlice.actions.updateThemeColors({ tertiary: value }))
-        }
-        validValue={theme?.colors?.tertiary}
-        value={tertiaryColor}
-      />
+      <ThemeValues />
     </Pane>
   );
 };

--- a/editor/src/components/inspector/inspector-styles.js
+++ b/editor/src/components/inspector/inspector-styles.js
@@ -13,4 +13,5 @@ export const Pane = styled.div`
   flex: 1;
   z-index: 1;
   padding: 10px;
+  overflow-y: scroll;
 `;

--- a/editor/src/components/inspector/theme-values.tsx
+++ b/editor/src/components/inspector/theme-values.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useDispatch, useSelector } from 'react-redux';
+import { deckSlice, themeSelector } from '../../slices/deck-slice';
+import { ColorPickerInput } from '../inputs/color';
+import { SpectacleTheme } from '../../types/theme';
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: 50% 50%;
+  grid-column-gap: 10px;
+  width: calc(100% - 10px);
+`;
+
+export const ThemeValues = () => {
+  const dispatch = useDispatch();
+  const themeValues = useSelector<{}, SpectacleTheme>(themeSelector);
+  const [inputState, setInputState] = useState(themeValues);
+
+  return (
+    <Container>
+      {'colors' in themeValues &&
+        Object.keys(themeValues.colors).map((colorKey) => (
+          <ColorPickerInput
+            onChangeInput={(value) =>
+              setInputState((prevState) => {
+                return {
+                  ...prevState,
+                  colors: { ...prevState.colors, [colorKey]: value }
+                };
+              })
+            }
+            key={`${colorKey}-color-value`}
+            label={
+              colorKey[0].toUpperCase() + colorKey.slice(1, colorKey.length)
+            }
+            onUpdateValue={(value) =>
+              dispatch(
+                deckSlice.actions.updateThemeColors({ [colorKey]: value })
+              )
+            }
+            validValue={themeValues?.colors[colorKey]}
+            value={inputState.colors[colorKey]}
+          />
+        ))}
+    </Container>
+  );
+};

--- a/editor/src/types/theme.ts
+++ b/editor/src/types/theme.ts
@@ -1,0 +1,7 @@
+export interface SpectacleTheme {
+  colors: Record<string, string>;
+  size: Record<string, number>;
+  fonts: Record<string, string>;
+  fontSizes: Record<string, string>;
+  space: number[];
+}

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                             /* Allow javascript files to be compiled. */
+    "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     "jsx": "react",                                 /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
@@ -19,7 +19,7 @@
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,                      /* Do not emit comments to output. */
-    "noEmit": true,                                 /* Do not emit outputs. */
+    "noEmit": false,                                 /* Do not emit outputs. */
     // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */

--- a/editor/yarn.lock
+++ b/editor/yarn.lock
@@ -2398,6 +2398,14 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -2546,6 +2554,16 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-redux@^7.1.16":
+  version "7.1.16"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.16.tgz#0fbd04c2500c12105494c83d4a3e45c084e3cb21"
+  integrity sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
 "@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
@@ -2606,6 +2624,15 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/styled-components@^5.1.9":
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.9.tgz#00d3d84b501420521c4db727e3c195459f87a6cf"
+  integrity sha512-kbEG6YlwK8rucITpKEr6pA4Ho9KSQHUUOzZ9lY3va1mtcjvS3D0wDciFyHEiNHKLL/npZCKDQJqm0x44sPO9oA==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    csstype "^3.0.2"
 
 "@types/tapable@*", "@types/tapable@^1.0.5":
   version "1.0.6"


### PR DESCRIPTION
Dynamically load all the color theme values and apply the changes across the entire deck when updated.

![Screen Recording (Google Chrome)](https://user-images.githubusercontent.com/1738349/111820426-7ba50a00-88af-11eb-9d32-77b00554d92a.gif)

- [ ] Tests are on-hold because we need to update core Spectacle to export the Contexts and default themes since we are using the esm import paths