### PR TITLE
Fix container sizing and scroll.

### DIFF
--- a/editor/src/components/user-interface/editor-styles.ts
+++ b/editor/src/components/user-interface/editor-styles.ts
@@ -24,6 +24,7 @@ export const EditorCanvas = styled.div`
   flex: 1;
   align-items: center;
   justify-content: center;
+  overflow: scroll;
 
   ${SlideScaleWrapper} {
     box-shadow: 1px 2px 5px ${defaultTheme.scales.neutral.N8A};


### PR DESCRIPTION
Previously the middle container would push the timeline out of the way and we could not scroll the controls. This fixes that when the window isn't tall enough.

Fixes #22 