### PR TITLE
Don't auto-focus MD input

### DIFF
--- a/src/components/inputs/md.tsx
+++ b/src/components/inputs/md.tsx
@@ -22,7 +22,6 @@ export const MdInput: React.FC<Props> = ({ label, value, onValueChange }) => {
         width="auto"
         height="150px"
         showGutter={false}
-        focus
       />
     </FormField>
   );


### PR DESCRIPTION
WARNING: BIG PR INCOMING.

Remove auto-focus of MD input field so that you can select elements without the MD input hijacking focus. This means you can click an element, then `Cmd + C` and `Cmd + P` to copy/paste, as you'd expect to be able to do.

I'm wondering how this behavior would feel:

- First click on element selects it, doesn't focus MD input.
- Click on selected element again, it focuses MD input.

Any thoughts on that?