### PR TITLE
Disable option to nest boxes and grids

### DIFF
--- a/src/components/user-interface/menu-bar.tsx
+++ b/src/components/user-interface/menu-bar.tsx
@@ -132,7 +132,7 @@ export const MenuBar = () => {
                     return (
                       <Tooltip
                         content={
-                          'This element can only be added to root-level slides'
+                          'This element can only be added to the root level of slides'
                         }
                         position={Position.RIGHT}
                       >


### PR DESCRIPTION
Closes #53 

Disables option to add grid or box elements if anything other than the root slide is selected. I also added a conditional tooltip that appears if the user tries to nest a box or grid. 

<img width="559" alt="image" src="https://user-images.githubusercontent.com/33091572/118521242-d40a5380-b708-11eb-90f3-e7d875a61f9e.png">

