### PR TITLE
Separate width and height from free-movement

### DIFF
--- a/src/components/inspector/box-format-controls.tsx
+++ b/src/components/inspector/box-format-controls.tsx
@@ -4,6 +4,7 @@ import { Accordion } from '../user-interface/accordion';
 import { BorderFormatControls } from './border-format-controls';
 import { ElementControlsProps } from './element-controls-props';
 import { FreeMovementControls } from './free-movement-controls';
+import { ResizeControls } from './resize-controls';
 
 export const BoxFormatControls: React.FC<ElementControlsProps> = ({
   selectedElement,
@@ -19,6 +20,7 @@ export const BoxFormatControls: React.FC<ElementControlsProps> = ({
   return (
     <>
       <FreeMovementControls {...{ selectedElement, editableElementChanged }} />
+      <ResizeControls {...{ selectedElement, editableElementChanged }} />
       <Accordion label="Styling">
         <ColorPickerInput
           disabled={!selectedElement?.props?.backgroundColor}

--- a/src/components/inspector/codepane-format-controls.tsx
+++ b/src/components/inspector/codepane-format-controls.tsx
@@ -4,6 +4,7 @@ import { ElementControlsProps } from './element-controls-props';
 import { SelectInput } from '../inputs/select';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { FreeMovementControls } from './free-movement-controls';
+import { ResizeControls } from './resize-controls';
 
 const availableLanguages = (SyntaxHighlighter as any).supportedLanguages.map(
   (language: string) => ({
@@ -34,6 +35,7 @@ export const CodePaneFormatControls: React.FC<ElementControlsProps> = ({
   return (
     <React.Fragment>
       <FreeMovementControls {...{ selectedElement, editableElementChanged }} />
+      <ResizeControls {...{ selectedElement, editableElementChanged }} />
       <MdInput
         label="Content"
         value={content}

--- a/src/components/inspector/free-movement-controls.tsx
+++ b/src/components/inspector/free-movement-controls.tsx
@@ -221,65 +221,6 @@ export const FreeMovementControls: React.FC<ElementControlsProps> = ({
                 });
               }}
             />
-
-            <TextInputField
-              label="Width:"
-              value={inputState.width}
-              onBlur={(e: FocusEvent<HTMLInputElement>) => {
-                const { value } = e.target;
-                handleOnEvent({
-                  value: value,
-                  shouldSetInputState: true,
-                  valueToChangeName: 'width',
-                  displayValueToChangeName: 'width',
-                  valueToChangeCSSName: 'width',
-                  valueAsCSSValue: value,
-                  validator: isValidCSSSize
-                });
-              }}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                const { value } = e.target;
-                setInputState({ ...inputState, width: value });
-                handleOnEvent({
-                  value,
-                  shouldSetInputState: false,
-                  valueToChangeName: 'width',
-                  displayValueToChangeName: 'width',
-                  valueToChangeCSSName: 'width',
-                  valueAsCSSValue: value,
-                  validator: isValidCSSSize
-                });
-              }}
-            />
-            <TextInputField
-              label="Height:"
-              value={inputState.height}
-              onBlur={(e: FocusEvent<HTMLInputElement>) => {
-                const { value } = e.target;
-                handleOnEvent({
-                  value: value,
-                  shouldSetInputState: true,
-                  valueToChangeName: 'height',
-                  displayValueToChangeName: 'height',
-                  valueToChangeCSSName: 'height',
-                  valueAsCSSValue: value,
-                  validator: isValidCSSSize
-                });
-              }}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                const { value } = e.target;
-                setInputState({ ...inputState, height: value });
-                handleOnEvent({
-                  value,
-                  shouldSetInputState: false,
-                  valueToChangeName: 'height',
-                  displayValueToChangeName: 'height',
-                  valueToChangeCSSName: 'height',
-                  valueAsCSSValue: value,
-                  validator: isValidCSSSize
-                });
-              }}
-            />
           </SplitContainer>
         ) : (
           <></>
@@ -292,7 +233,7 @@ export const FreeMovementControls: React.FC<ElementControlsProps> = ({
 const Container = styled(FormField)`
   display: grid;
   margin-top: 10px;
-  > div {
+  > div:first-of-type {
     margin-bottom: 12px;
     label {
       font-weight: 400;

--- a/src/components/inspector/grid-format-controls.tsx
+++ b/src/components/inspector/grid-format-controls.tsx
@@ -5,6 +5,7 @@ import { convertNumberToGridPercent } from '../../util/convert-number-to-grid';
 import { isValidCSSSize } from '../../util/is-valid-css-size';
 import { ElementControlsProps } from './element-controls-props';
 import { FreeMovementControls } from './free-movement-controls';
+import { ResizeControls } from './resize-controls';
 
 export const GridFormatControls: React.FC<ElementControlsProps> = ({
   selectedElement,
@@ -99,6 +100,7 @@ export const GridFormatControls: React.FC<ElementControlsProps> = ({
   return (
     <>
       <FreeMovementControls {...{ selectedElement, editableElementChanged }} />
+      <ResizeControls {...{ selectedElement, editableElementChanged }} />
       <TextInputField
         label="Number of Columns"
         value={inputState.columnNumber}

--- a/src/components/inspector/image-controls.tsx
+++ b/src/components/inspector/image-controls.tsx
@@ -3,6 +3,7 @@ import { ElementControlsProps } from './element-controls-props';
 import { TextInputField } from 'evergreen-ui';
 import { isValidUrl } from '../../util/is-valid-url';
 import { FreeMovementControls } from './free-movement-controls';
+import { ResizeControls } from './resize-controls';
 
 export const ImageControls: React.FC<ElementControlsProps> = ({
   selectedElement,
@@ -21,10 +22,8 @@ export const ImageControls: React.FC<ElementControlsProps> = ({
 
   return (
     <div>
-      <FreeMovementControls
-        selectedElement={selectedElement}
-        editableElementChanged={editableElementChanged}
-      />
+      <FreeMovementControls {...{ selectedElement, editableElementChanged }} />
+      <ResizeControls {...{ selectedElement, editableElementChanged }} />
       <TextInputField
         label="Image URL"
         placeholder="https://..."

--- a/src/components/inspector/md-format-controls.tsx
+++ b/src/components/inspector/md-format-controls.tsx
@@ -9,6 +9,7 @@ import { MarkdownControls } from './markdown-controls';
 import { TextControls } from './text-controls';
 import { Accordion } from '../user-interface/accordion';
 import { FreeMovementControls } from './free-movement-controls';
+import { ResizeControls } from './resize-controls';
 
 export const MdFormatControls: React.FC<ElementControlsProps> = ({
   selectedElement,
@@ -33,6 +34,7 @@ export const MdFormatControls: React.FC<ElementControlsProps> = ({
   return (
     <>
       <FreeMovementControls {...{ selectedElement, editableElementChanged }} />
+      <ResizeControls {...{ selectedElement, editableElementChanged }} />
       <Accordion label="Markdown Content">
         <MdInput
           label="Content"

--- a/src/components/inspector/resize-controls.tsx
+++ b/src/components/inspector/resize-controls.tsx
@@ -1,0 +1,180 @@
+import { TextInputField } from 'evergreen-ui';
+import React, {
+  ChangeEvent,
+  FocusEvent,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
+import styled from 'styled-components';
+import { isValidCSSSize } from '../../util/is-valid-css-size';
+import { ElementControlsProps } from './element-controls-props';
+
+export const ResizeControls: React.FC<ElementControlsProps> = ({
+  selectedElement,
+  editableElementChanged
+}) => {
+  const [inputState, setInputState] = useState({
+    width: selectedElement?.props?.width || 0,
+    height: selectedElement?.props?.height || 0
+  });
+
+  /* Update forms with values from dragged selection frame */
+  useEffect(() => {
+    setInputState({
+      width: selectedElement?.props?.width,
+      height: selectedElement?.props?.height
+    });
+  }, [selectedElement]);
+
+  //   const [freeMovement, setFreeMovement] = useState(inputState.freeMovement);
+  const freeMovement = selectedElement?.props?.componentProps?.isFreeMovement;
+
+  const handleComponentElementChanged = useCallback(
+    (propName: string, val: string | number | boolean) => {
+      if (selectedElement) {
+        editableElementChanged({
+          componentProps: {
+            ...selectedElement.props?.componentProps,
+            [propName]: val
+          }
+        });
+      }
+    },
+    [editableElementChanged, selectedElement]
+  );
+
+  const handleDefaultElementChanged = useCallback(
+    (propName: string, val: string | number) => {
+      if (selectedElement) {
+        editableElementChanged({
+          [propName]: val
+        });
+      }
+    },
+    [editableElementChanged, selectedElement]
+  );
+
+  const handleOnEvent = useCallback(
+    (options: {
+      value: string | number;
+      shouldSetInputState: boolean;
+      displayValueToChangeName: string;
+      valueToChangeName: string;
+      valueToChangeCSSName: string;
+      valueAsCSSValue: string;
+      validator: Function;
+    }) => {
+      if (options.shouldSetInputState) {
+        setInputState({
+          ...inputState,
+          [options.valueToChangeName]:
+            inputState[
+              options.displayValueToChangeName as keyof typeof inputState
+            ]
+        });
+      } else if (options.validator(options.value)) {
+        if (options.shouldSetInputState) {
+          setInputState({
+            ...inputState,
+            [options.displayValueToChangeName]: options.value,
+            [options.valueToChangeName]: options.value
+          });
+        }
+        handleComponentElementChanged(options.valueToChangeName, options.value);
+        handleDefaultElementChanged(
+          options.valueToChangeCSSName,
+          options.valueAsCSSValue
+        );
+      }
+    },
+    [handleComponentElementChanged, handleDefaultElementChanged, inputState]
+  );
+
+  return (
+    <>
+      {freeMovement ? (
+        <SplitContainer>
+          <TextInputField
+            label="Width:"
+            value={inputState.width}
+            onBlur={(e: FocusEvent<HTMLInputElement>) => {
+              const { value } = e.target;
+              handleOnEvent({
+                value: value,
+                shouldSetInputState: true,
+                valueToChangeName: 'width',
+                displayValueToChangeName: 'width',
+                valueToChangeCSSName: 'width',
+                valueAsCSSValue: value,
+                validator: isValidCSSSize
+              });
+            }}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const { value } = e.target;
+              setInputState({ ...inputState, width: value });
+              handleOnEvent({
+                value,
+                shouldSetInputState: false,
+                valueToChangeName: 'width',
+                displayValueToChangeName: 'width',
+                valueToChangeCSSName: 'width',
+                valueAsCSSValue: value,
+                validator: isValidCSSSize
+              });
+            }}
+          />
+          <TextInputField
+            label="Height:"
+            value={inputState.height}
+            onBlur={(e: FocusEvent<HTMLInputElement>) => {
+              const { value } = e.target;
+              handleOnEvent({
+                value: value,
+                shouldSetInputState: true,
+                valueToChangeName: 'height',
+                displayValueToChangeName: 'height',
+                valueToChangeCSSName: 'height',
+                valueAsCSSValue: value,
+                validator: isValidCSSSize
+              });
+            }}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const { value } = e.target;
+              setInputState({ ...inputState, height: value });
+              handleOnEvent({
+                value,
+                shouldSetInputState: false,
+                valueToChangeName: 'height',
+                displayValueToChangeName: 'height',
+                valueToChangeCSSName: 'height',
+                valueAsCSSValue: value,
+                validator: isValidCSSSize
+              });
+            }}
+          />
+        </SplitContainer>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+};
+
+const SplitContainer = styled.div`
+  display: grid;
+  grid-template-columns: 50% 50%;
+  grid-column-gap: 10px;
+  width: calc(100% - 10px);
+  margin-bottom: 12px;
+
+  > div {
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+
+    label {
+      margin-right: 10px;
+    }
+  }
+`;


### PR DESCRIPTION
Making this PR to decouple the width/height inputs from the positioning inputs from free movement. This is for the other components like `Progress` and `FullScreen` that might not have resizing options or for future components that may not need these controls.
