### PR TITLE
Fix image controls

### DIFF
--- a/src/components/inspector/image-controls.tsx
+++ b/src/components/inspector/image-controls.tsx
@@ -9,16 +9,17 @@ export const ImageControls: React.FC<ElementControlsProps> = ({
   selectedElement,
   editableElementChanged
 }) => {
-  const [desiredSrc, setDesiredSrc] = React.useState(
-    selectedElement?.props?.src || ''
-  );
+  const desiredSrc = selectedElement?.props?.src || '';
+  const [inputState, setInputState] = React.useState({
+    desiredSrc
+  });
 
-  // If desired src is valid, update the element in the store.
-  React.useEffect(() => {
-    if (isValidUrl(desiredSrc) && desiredSrc !== selectedElement?.props?.src) {
-      editableElementChanged({ src: desiredSrc });
-    }
-  }, [desiredSrc, editableElementChanged, selectedElement?.props?.src]);
+  const handleValueChanged = React.useCallback(
+    (propName: string, value) => {
+      editableElementChanged({ [propName]: value });
+    },
+    [editableElementChanged]
+  );
 
   return (
     <div>
@@ -28,12 +29,22 @@ export const ImageControls: React.FC<ElementControlsProps> = ({
         label="Image URL"
         placeholder="https://..."
         value={desiredSrc}
-        onChange={(e: ChangeEvent<HTMLInputElement>) =>
-          setDesiredSrc(e.target.value)
-        }
-        onBlur={() => {
-          if (!isValidUrl(desiredSrc)) {
-            setDesiredSrc(selectedElement?.props?.src || '');
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          const { value } = e.target;
+          if (isValidUrl(value)) {
+            setInputState({ ...inputState, desiredSrc: value });
+            handleValueChanged('src', value);
+          } else {
+            setInputState({ ...inputState, desiredSrc: value });
+          }
+        }}
+        onBlur={(e: ChangeEvent<HTMLInputElement>) => {
+          const { value } = e.target;
+          if (isValidUrl(value)) {
+            setInputState({ ...inputState, desiredSrc: value });
+            handleValueChanged('src', value);
+          } else {
+            setInputState({ ...inputState, desiredSrc });
           }
         }}
       />


### PR DESCRIPTION
There are a couple bugs I noticed with the images, but this PR primarily fixes the the bug that occurs when you click on two images back to back with different sources. Since the input state doesn't update with the new source, the second image clicked on will have its source changed to the first image's source:

![2021-06-18 15 34 33](https://user-images.githubusercontent.com/33091572/122621549-bb17f980-d04a-11eb-8841-06ea171b2295.gif)

There's another bug that happens when cropping or resizing an image. The X and Y position of the object switches to a really high number:

![2021-06-18 15 37 59](https://user-images.githubusercontent.com/33091572/122621717-3a0d3200-d04b-11eb-8db7-b0ff445cf696.gif)

It might be worth looking into [Moveable's clipable](https://daybrush.com/moveable/release/latest/doc/Moveable.Clippable.html) for cropping instead of cropperjs