### PR TITLE
Enable source maps in development mode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    "sourceMap": true,                              /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
     // "outDir": "./",                              /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -4,43 +4,48 @@ import webpack from 'webpack';
 
 const __dirname = path.resolve();
 
-export default {
-  output: {
-    path: path.resolve(__dirname, 'build'),
-    filename: 'app.js'
-  },
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-    modules: [path.join(__dirname, 'src'), 'node_modules']
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: 'ts-loader',
-        exclude: /node_modules/
-      },
-      {
-        test: /\.js/,
-        exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader'
+export default (env, argv) => {
+  const isDevelopment = argv.mode === 'development';
+
+  return {
+    devtool: isDevelopment ? 'cheap-module-source-map' : false,
+    output: {
+      path: path.resolve(__dirname, 'build'),
+      filename: 'app.js'
+    },
+    resolve: {
+      extensions: ['.tsx', '.ts', '.js'],
+      modules: [path.join(__dirname, 'src'), 'node_modules']
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: 'ts-loader',
+          exclude: /node_modules/
         },
-        resolve: {
-          fullySpecified: false
+        {
+          test: /\.js/,
+          exclude: /node_modules/,
+          use: {
+            loader: 'babel-loader'
+          },
+          resolve: {
+            fullySpecified: false
+          }
         }
-      }
+      ]
+    },
+    devServer: {
+      historyApiFallback: true
+    },
+    plugins: [
+      new webpack.ProvidePlugin({
+        process: 'process/browser'
+      }),
+      new HtmlWebpackPlugin({
+        template: './src/index.html'
+      })
     ]
-  },
-  devServer: {
-    historyApiFallback: true
-  },
-  plugins: [
-    new webpack.ProvidePlugin({
-      process: 'process/browser'
-    }),
-    new HtmlWebpackPlugin({
-      template: './src/index.html'
-    })
-  ]
+  };
 };


### PR DESCRIPTION
Allows debugging over browser devtool protocols when running in development mode (`yarn start`)

For example, using the [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) extension in VS Code -- 

```json
// .vscode/launch.json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "pwa-chrome",
            "request": "launch",
            "name": "Launch Chrome against localhost",
            "url": "http://localhost:8080",
            "webRoot": "${workspaceFolder}",
            "smartStep": true,
            "skipFiles": [
              "<node_internals>/**",
              "${workspaceFolder}/node_modules/**"
            ]
        }
    ]
}

```