### PR TITLE
Wait for throttled function to run before showing formatting controls

### DIFF
--- a/src/components/inspector/md-format-controls.tsx
+++ b/src/components/inspector/md-format-controls.tsx
@@ -30,6 +30,12 @@ export const MdFormatControls: React.FC<ElementControlsProps> = ({
     500,
     [selectedElement]
   );
+  /**
+   * useThrottleFn returns `null` on first render
+   * this ensures we have a boolean "false" before showing formatting controls to avoid breaking header styles - Issue 135
+   */
+  const shouldShowFormatting =
+    doesContentContainList === false && doesContentContainHeader === false;
 
   return (
     <>
@@ -48,7 +54,7 @@ export const MdFormatControls: React.FC<ElementControlsProps> = ({
           <ListControls {...{ selectedElement, editableElementChanged }} />
         </>
       )}
-      {!doesContentContainHeader && !doesContentContainList && (
+      {shouldShowFormatting && (
         <>
           <Accordion label="Formatting">
             <MarkdownControls


### PR DESCRIPTION
Fix for https://github.com/FormidableLabs/spectacle-visual-editor/issues/135

MDFormatControls includes two throttled checks for list and header content and when both are false, we show the formatting controls - however, the way the `useThrottleFn` works will actually return `null` on first render. This means that when we were simply checking `!doesContentContainList` and `!doesContentContainHeader` it allowed the formatting controls to render which modified the underlying header styling. This change makes it so we wait for a boolean return from the regex before we decide whether or not the content contains lists or headers

**Before:**
![before_headers](https://user-images.githubusercontent.com/7433825/140823323-6218eec3-1db9-40f7-8c87-c6dd68fe1fca.gif)

**After:**
![after_headers](https://user-images.githubusercontent.com/7433825/140823342-a307c2c1-0eca-464a-a120-a070405172c9.gif)

