### PR TITLE
Run webpack and functions server using netlify dev

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,8 @@
 
 [[plugins]]
     package = './plugins/copy-chromium-binaries'
+
+[dev]
+    command= "yarn dev"
+    targetPort= 3000
+    port = 8080

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "src/index.js",
   "type": "commonjs",
   "scripts": {
-    "start": "webpack serve --mode=development --open --hot",
-    "netstart": "yarn netlify dev -p 8081",
+    "start": "netlify dev",
+    "dev": "webpack serve --mode=development --hot",
     "build": "webpack --mode=production",
     "prettier-check": "yarn prettier --check src/**",
     "prettier-fix": "yarn prettier --write src/**",

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -38,9 +38,7 @@ export default (env, argv) => {
     },
     devServer: {
       historyApiFallback: true,
-      proxy: {
-        '/.netlify/functions/': 'http://localhost:8081'
-      }
+      port: 3000
     },
     plugins: [
       new webpack.ProvidePlugin({


### PR DESCRIPTION
- Changes webpack port to 3000, only used by netlify dev
- The app still runs on 8080 with FE and Functions both proxied via it
- Removed the proxy from webpack since netlify dev handles that

Functions Path: http://localhost:8080/.netlify/functions/hello-world
UI Path: http://localhost:8080/