### PR TITLE
Bug - update bounding rect on position type change - Closes #154

### DIFF
--- a/src/components/slide/selection-frame.tsx
+++ b/src/components/slide/selection-frame.tsx
@@ -132,13 +132,17 @@ export const SelectionFrame: React.FC<Props> = ({ children, treeId }) => {
   }, [children, editableElementId]);
 
   /**
-   *  If the child's dimensions change, let the moveable instance know
+   *  If the child's dimensions or css position change, let the moveable instance know
    */
   useEffect(() => {
     if (moveableRef?.current?.props?.target) {
       moveableRef.current.updateRect();
     }
-  }, [children?.props?.width, children?.props?.height]);
+  }, [
+    children?.props?.width,
+    children?.props?.height,
+    children?.props?.position
+  ]);
 
   /**
    *  If the child's content changes and can cause resizing, let the moveable instance know


### PR DESCRIPTION
Address #154 

Minor update to ensure that the `children.props.position` value is watched for changes to ensure the selection bounding box is correct.

Steps to verify:
1. Select a box
2. Change the dimensions of the box via dragging
3. Change the positioning type from inline to absolute
4. See the alignment frame correctly bound by selection box 

**Before - frame is misaligned:**
<img width="592" alt="before" src="https://user-images.githubusercontent.com/7433825/142952997-9f07aa1e-074a-40a4-9beb-6e8db27b5bfa.png">

**After:**
![position_change](https://user-images.githubusercontent.com/7433825/142953061-d077364f-a6bf-4da1-9f20-a78005637d13.gif)

