### PR TITLE
Fix blockquote rendering in visual edit mode

### DIFF
--- a/src/components/user-interface/inline-editor/visual-editor.tsx
+++ b/src/components/user-interface/inline-editor/visual-editor.tsx
@@ -78,7 +78,10 @@ const extraMarkdownStyles = {
   }
 };
 
-/* Wrapper for spectacle UnorderedList and OrderedList - renders children as ListItem components */
+/*
+  Wrapper for spectacle’s UnorderedList and OrderedList components.
+  Renders children as ListItem components.
+*/
 const ListWrapper = ({
   component: Component,
   children,
@@ -94,6 +97,21 @@ const ListWrapper = ({
       return <ListItem key={child.key} {...childProps} />;
     })}
   </Component>
+);
+
+/*
+  Wrapper for spectacle’s Quote component.
+  Renders children within Text component to match MD parsing on spectacle.
+*/
+const QuoteWrapper = ({
+  children,
+  ...props
+}: {
+  children: React.ReactElement[];
+}) => (
+  <Quote {...props}>
+    <Text {...props}>{children}</Text>
+  </Quote>
 );
 
 export const VisualEditor = () => {
@@ -141,7 +159,7 @@ export const VisualEditor = () => {
     },
     blockquote: {
       element: 'div',
-      wrapper: <Quote {...componentProps} />
+      wrapper: <QuoteWrapper {...componentProps} />
     },
     'ordered-list-item': {
       element: 'li',


### PR DESCRIPTION
Closes https://github.com/FormidableLabs/spectacle-visual-editor/issues/158

The MD parser in spectacle seems to render a Text component as a child of the Quote component - this PR matches that behaviour whilst in visual edit mode for visual consistency.

https://user-images.githubusercontent.com/9557798/143582544-d8f7a7ae-a834-4e59-9f58-1cffaf9d56d3.mp4