### PR TITLE
Fix free movement on images

### DIFF
--- a/src/components/inspector/image-controls.tsx
+++ b/src/components/inspector/image-controls.tsx
@@ -1,9 +1,47 @@
 import React, { ChangeEvent } from 'react';
 import { ElementControlsProps } from './element-controls-props';
-import { TextInputField } from 'evergreen-ui';
+import {
+  Button,
+  CrossIcon,
+  IconButton,
+  Popover,
+  TextInputField,
+  TickIcon,
+  toaster
+} from 'evergreen-ui';
 import { isValidUrl } from '../../util/is-valid-url';
 import { FreeMovementControls } from './free-movement-controls';
 import { ResizeControls } from './resize-controls';
+import styled from 'styled-components';
+import Cropper from 'cropperjs';
+
+const CropperImageContainer = styled.div`
+  max-width: 400px;
+  height: 100%;
+`;
+
+const CropperImage = styled.img`
+  display: block;
+  max-width: 100%;
+`;
+
+const CropperButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 8px;
+  box-sizing: border-box;
+
+  button:first-child {
+    margin-right: 4px;
+  }
+`;
+
+const CropButton = styled(Button)`
+  width: 100%;
+  justify-content: center;
+`;
 
 export const ImageControls: React.FC<ElementControlsProps> = ({
   selectedElement,
@@ -13,6 +51,19 @@ export const ImageControls: React.FC<ElementControlsProps> = ({
   const [inputState, setInputState] = React.useState({
     desiredSrc
   });
+  const [isCropModalOpen, setCropModalOpen] = React.useState<boolean>(false);
+  const [
+    dialogImageRef,
+    setDialogImageRef
+  ] = React.useState<HTMLImageElement | null>();
+  const cropperInstance = React.useRef<Cropper | undefined>();
+  React.useEffect(() => {
+    if (dialogImageRef && isCropModalOpen) {
+      cropperInstance.current = new Cropper(dialogImageRef, {
+        // aspectRatio: 16 / 9
+      });
+    }
+  }, [dialogImageRef, isCropModalOpen]);
 
   const handleValueChanged = React.useCallback(
     (propName: string, value) => {
@@ -48,6 +99,44 @@ export const ImageControls: React.FC<ElementControlsProps> = ({
           }
         }}
       />
+      <Popover
+        onOpen={() => setCropModalOpen(true)}
+        onClose={() => {
+          setCropModalOpen(false);
+        }}
+        content={({ close }) => (
+          <CropperImageContainer>
+            <CropperImage
+              src={selectedElement?.props?.src}
+              ref={(r) => setDialogImageRef(r)}
+            />
+            <CropperButtonContainer>
+              <IconButton
+                onClick={() => {
+                  close();
+                  const e = cropperInstance.current?.getCroppedCanvas();
+
+                  if (!e) {
+                    return toaster.warning('Could not crop the image.');
+                  }
+                  handleValueChanged('croppedSrc', e.toDataURL());
+                }}
+                icon={TickIcon}
+                height={48}
+              />
+              <IconButton
+                onClick={() => {
+                  close();
+                }}
+                icon={CrossIcon}
+                height={48}
+              />
+            </CropperButtonContainer>
+          </CropperImageContainer>
+        )}
+      >
+        <CropButton>Crop Image</CropButton>
+      </Popover>
     </div>
   );
 };

--- a/src/components/slide/croppable-image.tsx
+++ b/src/components/slide/croppable-image.tsx
@@ -1,33 +1,5 @@
 import React from 'react';
-
-import Cropper from 'cropperjs';
-import { Dialog, CogIcon, IconButton, UndoIcon, toaster } from 'evergreen-ui';
-import { useDispatch } from 'react-redux';
 import { Image as SpectacleImage } from 'spectacle';
-import styled from 'styled-components';
-
-import { deckSlice } from '../../slices/deck-slice';
-
-const ButtonContainer = styled.div`
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  z-index: 10;
-`;
-
-const Overlay = styled.div<{
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-}>`
-  position: absolute;
-  left: ${(props) => props.left + 'px;'};
-  top: ${(props) => props.top + 'px;'};
-  width: ${(props) => props.width + 'px;'};
-  height: ${(props) => props.height + 'px;'};
-`;
-
 const Image = React.forwardRef<
   {},
   {
@@ -35,61 +7,10 @@ const Image = React.forwardRef<
     isSelected: boolean;
     croppedSrc?: string;
     onLoad?: React.ReactEventHandler<Record<string, unknown>>;
+    componentProps?: any;
   }
->((props, forwardedRef) => {
+>(function InternalImageWithRef(props, forwardedRef) {
   const { onLoad } = props;
-
-  const [
-    dialogImageRef,
-    setDialogImageRef
-  ] = React.useState<HTMLImageElement | null>();
-  const [isCropModalOpen, setCropModalOpen] = React.useState<boolean>(false);
-  const [
-    spectacleImage,
-    setSpectacleImage
-  ] = React.useState<HTMLImageElement | null>(null);
-  const [hasImageLoaded, setImageLoaded] = React.useState(false);
-  const [imageDimensions, setImageDimensions] = React.useState<{
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-  } | null>(null);
-
-  const cropperInstance = React.useRef<Cropper | undefined>();
-
-  React.useEffect(() => {
-    if (dialogImageRef && isCropModalOpen) {
-      cropperInstance.current = new Cropper(dialogImageRef, {
-        aspectRatio: 16 / 9
-      });
-    }
-  }, [dialogImageRef, isCropModalOpen]);
-
-  React.useEffect(() => {
-    let observer: ResizeObserver;
-
-    if (spectacleImage) {
-      observer = new window.ResizeObserver((elements) => {
-        const target = elements[0].target as HTMLImageElement;
-
-        setImageDimensions({
-          left: target.offsetLeft,
-          top: target.offsetTop,
-          width: target.offsetWidth,
-          height: target.offsetHeight
-        });
-      });
-
-      observer.observe(spectacleImage);
-    }
-
-    return () => {
-      if (observer && spectacleImage) {
-        observer.unobserve(spectacleImage);
-      }
-    };
-  }, [spectacleImage]);
 
   const imageSource = React.useMemo(() => {
     return props.croppedSrc || props.src;
@@ -102,50 +23,19 @@ const Image = React.forwardRef<
       } else if (typeof forwardedRef === 'object' && forwardedRef) {
         forwardedRef.current = ref;
       }
-
-      setSpectacleImage(ref);
     },
     [forwardedRef]
   );
 
   const interceptOnLoad = React.useCallback(
     (e: React.SyntheticEvent<Record<string, unknown>, Event>) => {
-      setImageLoaded(true);
       onLoad && onLoad(e);
     },
-    [onLoad, setImageLoaded]
+    [onLoad]
   );
-
-  const dispatch = useDispatch();
 
   return (
     <>
-      <Dialog
-        isShown={isCropModalOpen}
-        title="Edit your image"
-        onCloseComplete={() => setCropModalOpen(false)}
-        confirmLabel="Save changes"
-        width="75%"
-        onConfirm={() => {
-          const e = cropperInstance.current?.getCroppedCanvas();
-
-          if (!e) {
-            return toaster.warning('Could not crop the image.');
-          }
-
-          dispatch(
-            deckSlice.actions.editableElementChanged({
-              croppedSrc: e.toDataURL()
-            })
-          );
-
-          setCropModalOpen(false);
-        }}
-      >
-        <div>
-          <img src={props.src} ref={(r) => setDialogImageRef(r)} />
-        </div>
-      </Dialog>
       <SpectacleImage
         {...props}
         //  @ts-ignore
@@ -153,40 +43,6 @@ const Image = React.forwardRef<
         src={imageSource}
         onLoad={interceptOnLoad}
       />
-      {props.isSelected && hasImageLoaded && !!imageDimensions && (
-        <Overlay
-          left={imageDimensions.left}
-          top={imageDimensions.top}
-          width={imageDimensions.width}
-          height={imageDimensions.height}
-        >
-          <ButtonContainer>
-            {props.croppedSrc && (
-              <IconButton
-                onClick={() => {
-                  dispatch(
-                    deckSlice.actions.editableElementChanged({
-                      croppedSrc: undefined
-                    })
-                  );
-                }}
-                icon={UndoIcon}
-                height={48}
-                marginLeft="auto"
-                marginBottom="8px"
-              />
-            )}
-            <IconButton
-              onClick={() => {
-                setCropModalOpen(true);
-              }}
-              icon={CogIcon}
-              height={48}
-              marginLeft="auto"
-            />
-          </ButtonContainer>
-        </Overlay>
-      )}
     </>
   );
 });

--- a/src/components/slide/selection-frame.tsx
+++ b/src/components/slide/selection-frame.tsx
@@ -132,6 +132,30 @@ export const SelectionFrame: React.FC<Props> = ({ children, treeId }) => {
   }, [children, editableElementId]);
 
   /**
+   * If shift is held down, the image should keep its ratio when resizing
+   */
+  const [isShiftDown, setIsShiftDown] = useState(false);
+
+  const handleUserKeyPress = useCallback(
+    (event: KeyboardEvent, isKeyDown: boolean) => {
+      const { key } = event;
+      if (key === 'Shift') {
+        setIsShiftDown(isKeyDown);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', (event) =>
+      handleUserKeyPress(event, true)
+    );
+    window.addEventListener('keyup', (event) =>
+      handleUserKeyPress(event, false)
+    );
+  }, [handleUserKeyPress]);
+
+  /**
    *  If the child's dimensions or css position change, let the moveable instance know
    */
   useEffect(() => {
@@ -232,7 +256,7 @@ export const SelectionFrame: React.FC<Props> = ({ children, treeId }) => {
           resizable={RESIZABLE_ELEMENTS.includes(children.props.type)}
           onResize={handleOnResize}
           onResizeEnd={handleOnResizeEnd}
-          keepRatio={children.props.type === 'Image'}
+          keepRatio={isShiftDown}
           draggable={children.props.componentProps?.isFreeMovement}
           onDrag={handleOnDragMovement}
           onDragEnd={handleOnDragMovementEnd}


### PR DESCRIPTION
Closes #165 

The problem with the image not being moveable was that the cropping functionality covered the image. That prevented events from firing in the Moveable library. That should be fixed up now:

![2022-03-14 17 38 30](https://user-images.githubusercontent.com/33091572/158265751-6caa67db-9efc-4aee-badf-db62953708bf.gif)

In a similar vein though, I also wanted to fix up the UI for cropping images. I moved the crop feature to the controls section so that it could appear as a `Popover` rather than a `Dialog` (similar to Figma). I think it makes it feel a little less...intense as a functionality:

![2022-03-14 17 41 42](https://user-images.githubusercontent.com/33091572/158266155-61a483a3-b86b-46d7-90c4-7054ba920f9e.gif)

For the crop to work properly, and to allow images in different aspect ratios outside of the default image's ratio, I had to turn off `keepRatio` in `Moveable`. To keep the ratio when resizing, the user now has to hold shift (like in most other editing programs):

![2022-03-14 17 46 49](https://user-images.githubusercontent.com/33091572/158266820-fa476759-86b2-4c99-a227-67e6bc74eed7.gif)

Finally, I noticed a bug for the images that I'm not sure how to fix. When the user resizes an image while keeping the ratio to the right or downward, the image's position will fly into an extreme direction:

![2022-03-14 17 48 36](https://user-images.githubusercontent.com/33091572/158267009-bbb9648b-76a5-4f88-8c4f-b58428a04090.gif)





