### PR TITLE
Populate width/height inputs for text box absolute positioning

### DIFF
--- a/src/components/inspector/free-movement-controls.tsx
+++ b/src/components/inspector/free-movement-controls.tsx
@@ -44,14 +44,27 @@ export const FreeMovementControls: React.FC<ElementControlsProps> = ({
 
   /* Update forms with values from dragged selection frame */
   useEffect(() => {
+    if (!selectedElement?.props) {
+      console.error('selectedElement.props is undefined');
+      return;
+    }
+
+    const {
+      componentProps = {},
+      width: propsWidth = 0,
+      height: propsHeight = 0
+    } = selectedElement.props;
+
+    const { isFreeMovement, positionX = 0, positionY = 0 } = componentProps;
+
     setInputState({
-      freeMovement: !!selectedElement?.props?.componentProps?.isFreeMovement,
-      displayPositionX: selectedElement?.props?.componentProps?.positionX || 0,
-      displayPositionY: selectedElement?.props?.componentProps?.positionY || 0,
-      positionX: selectedElement?.props?.componentProps?.positionX || 0,
-      positionY: selectedElement?.props?.componentProps?.positionY || 0,
-      width: selectedElement?.props?.width || 0,
-      height: selectedElement?.props?.height || 0
+      freeMovement: !!isFreeMovement,
+      displayPositionX: positionX,
+      displayPositionY: positionY,
+      positionX: positionX,
+      positionY: positionY,
+      width: propsWidth,
+      height: propsHeight
     });
   }, [selectedElement]);
 

--- a/src/components/inspector/resize-controls.tsx
+++ b/src/components/inspector/resize-controls.tsx
@@ -21,6 +21,13 @@ export const ResizeControls: React.FC<ElementControlsProps> = ({
 
   /* Update forms with values from dragged selection frame */
   useEffect(() => {
+    if (!selectedElement?.props) {
+      console.error('selectedElement.props is undefined');
+      return;
+    }
+
+    const { width: propsWidth, height: propsHeight } = selectedElement.props;
+
     switch (selectedElement?.component) {
       case 'Markdown':
         // Set inputs to prop values with node offset values as fallback
@@ -37,14 +44,14 @@ export const ResizeControls: React.FC<ElementControlsProps> = ({
         }
 
         setInputState({
-          width: selectedElement?.props?.width || selectedElementWidth,
-          height: selectedElement?.props?.height || selectedElementHeight
+          width: propsWidth || selectedElementWidth,
+          height: propsHeight || selectedElementHeight
         });
         break;
       default:
         setInputState({
-          width: selectedElement?.props?.width,
-          height: selectedElement?.props?.height
+          width: propsWidth,
+          height: propsHeight
         });
     }
   }, [selectedElement]);


### PR DESCRIPTION
- Populates width/height inputs using selected element props with node offset width/height values as a fallback for textbox/Markdown components
- Keep `freeMovement` in sync with `inputState` value to prevent double-clicking toggle from hiding input fields.

closes #143 