### PR TITLE
Fix broken text alignments for basic layout templates

### DIFF
--- a/src/templates/basic-layouts.ts
+++ b/src/templates/basic-layouts.ts
@@ -7,18 +7,33 @@ export const basicLayout = (): {
   elementIds: string[];
   elementMap: DeckElementMap;
 } => {
-  const elementId = v4();
+  const elementId1 = v4();
+  const elementId2 = v4();
 
   return {
-    elementIds: [elementId],
+    elementIds: [elementId1, elementId2],
     elementMap: {
-      [elementId]: {
+      [elementId1]: {
         component: 'Markdown',
-        id: elementId,
+        id: elementId1,
+        props: {
+          componentProps: {
+            textAlign: 'center'
+          }
+        },
         parent: ROOT_ELEMENT,
         children: indentNormalizer(`
           # Header
-
+        `)
+      },
+      [elementId2]: {
+        component: 'Markdown',
+        id: elementId2,
+        props: {
+          componentProps: {}
+        },
+        parent: ROOT_ELEMENT,
+        children: indentNormalizer(`
           This is a paragraph.
         `)
       }
@@ -30,18 +45,33 @@ export const codePaneLayout = (): {
   elementIds: string[];
   elementMap: DeckElementMap;
 } => {
-  const elementId = v4();
+  const elementId1 = v4();
+  const elementId2 = v4();
 
   return {
-    elementIds: [elementId],
+    elementIds: [elementId1, elementId2],
     elementMap: {
-      [elementId]: {
+      [elementId1]: {
         component: 'Markdown',
-        id: elementId,
+        id: elementId1,
+        props: {
+          componentProps: {
+            textAlign: 'center'
+          }
+        },
         parent: ROOT_ELEMENT,
         children: indentNormalizer(`
           # Header
-
+        `)
+      },
+      [elementId2]: {
+        component: 'Markdown',
+        id: elementId2,
+        props: {
+          componentProps: {}
+        },
+        parent: ROOT_ELEMENT,
+        children: indentNormalizer(`
           \`\`\`jsx
           export function Counter() {
             const [counter, setCounter] = useState(0);


### PR DESCRIPTION
Closes #168 

In DraftJS, text alignment is a defining characteristic of a block, therefore content pieces with different text alignments need to be mapped into separate block elements.

**Before:**

https://user-images.githubusercontent.com/20046764/169158150-73bc4c9c-e1b4-4f69-8c65-b00af4c2ed11.mov

**After:**

https://user-images.githubusercontent.com/20046764/169158181-fda50f0a-59de-4199-a2d8-41d02241c8f3.mov
