### PR TITLE
Fix child prop types with PropsWithChildren for React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-dnd-html5-backend": "^14.0.0",
     "react-dom": "^18.1.0",
     "react-moveable": "^0.26.2",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.2",
     "react-syntax-highlighter": "12.2.1",
     "react-use": "^17.2.1",
     "redux-undo": "^1.0.1",
@@ -57,6 +57,10 @@
     "util": "^0.12.3",
     "uuid": "^8.3.2",
     "webfontloader": "^1.6.28"
+  },
+  "resolutions": {
+    "@types/react": "^18.0.12",
+    "@types/react-dom": "^18.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.13",
@@ -74,9 +78,9 @@
     "@types/lodash-es": "^4.17.4",
     "@types/node": "^14.14.35",
     "@types/puppeteer": "^5.4.4",
-    "@types/react": "^17.0.3",
-    "@types/react-dom": "^18.0.4",
-    "@types/react-redux": "^7.1.16",
+    "@types/react": "^18.0.12",
+    "@types/react-dom": "^18.0.5",
+    "@types/react-redux": "^7.1.24",
     "@types/styled-components": "^5.1.9",
     "@types/styled-system": "^5.1.10",
     "@types/uuid": "^8.3.0",

--- a/src/components/helpers/drag-wrapper.tsx
+++ b/src/components/helpers/drag-wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
 /**
@@ -23,7 +23,7 @@ interface Props extends ElementLocation {
   orientation: 'horizontal' | 'vertical';
 }
 
-export const DragWrapper: React.FC<Props> = ({
+export const DragWrapper = ({
   children,
   index,
   parentIndex,
@@ -31,7 +31,7 @@ export const DragWrapper: React.FC<Props> = ({
   onDrag,
   onDrop,
   orientation
-}) => {
+}: PropsWithChildren<Props>) => {
   const ref = React.useRef<HTMLDivElement>(null);
 
   const [{ handlerId }, drop] = useDrop({

--- a/src/components/slide/slide-timeline.tsx
+++ b/src/components/slide/slide-timeline.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { PropsWithChildren, useCallback } from 'react';
 import { css } from 'styled-components';
 import { TimelineSlideViewer } from './slide-viewer/timeline-slide-viewer';
 
@@ -17,12 +17,12 @@ interface Props {
 /**
  * SlideTimeline is a vertical strip used to scroll and view all the slides in a deck.
  */
-export const SlideTimeline: React.FC<Props> = ({
+export const SlideTimeline = ({
   children,
   onSlideClick,
   template,
   onTemplateClick
-}) => {
+}: PropsWithChildren<Props>) => {
   const handleKeyPress = useCallback(
     (key: string, id: string) => {
       if (key === 'Enter') {

--- a/src/components/slide/slide-viewer/slide-viewer-wrapper.tsx
+++ b/src/components/slide/slide-viewer/slide-viewer-wrapper.tsx
@@ -6,15 +6,15 @@ import {
   themeSelector
 } from '../../../slices/deck-slice';
 import { ThemeProvider } from 'styled-components';
-import React, { useMemo } from 'react';
+import React, { PropsWithChildren, useMemo } from 'react';
 
 /**
  * Wrapper for SlideViewers
  */
-export const SlideViewerWrapper: React.FC<{ slideIndex?: number }> = ({
+export const SlideViewerWrapper = ({
   slideIndex,
   children
-}) => {
+}: PropsWithChildren<{ slideIndex?: number }>) => {
   const theme = useSelector(themeSelector);
   const slides = useSelector(slidesSelector);
   const activeSlide = useSelector(activeSlideSelector);

--- a/src/components/slide/slide-viewer/slide-viewer.tsx
+++ b/src/components/slide/slide-viewer/slide-viewer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { SlideViewerWrapper } from './slide-viewer-wrapper';
 
 interface Props {
@@ -10,11 +10,11 @@ interface Props {
  * SlideViewer is an un-styled wrapper that provides the context data
  * required for rendering slide components.
  */
-export const SlideViewer: React.FC<Props> = ({
+export const SlideViewer = ({
   children,
   scale,
   slideProps
-}) => {
+}: PropsWithChildren<Props>) => {
   // Flatten out slides
   const slides = React.useMemo(() => {
     const slideEls = (children instanceof Array

--- a/src/components/slide/slide-viewer/timeline-slide-viewer.tsx
+++ b/src/components/slide/slide-viewer/timeline-slide-viewer.tsx
@@ -1,14 +1,20 @@
 import { useDispatch } from 'react-redux';
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  PropsWithChildren
+} from 'react';
 import {
   activeSlideIdSelector,
   deckSlice,
   slideTemplateOpenSelector
 } from '../../../slices/deck-slice';
 import { SlideViewerWrapper } from './slide-viewer-wrapper';
-import { DndProvider } from 'react-dnd';
+import * as ReactDND from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { DragWrapper } from '../../helpers/drag-wrapper';
+import { DragWrapper, ElementLocation } from '../../helpers/drag-wrapper';
 import styled, { css } from 'styled-components';
 import {
   TrashIcon,
@@ -28,15 +34,22 @@ interface Props {
 }
 
 /**
+ * We need to retype the import as React.FC no longer includes children
+ */
+const DndProvider = ReactDND.DndProvider as React.FC<
+  PropsWithChildren<ReactDND.DndProviderProps<unknown, unknown>>
+>;
+
+/**
  * Slide Viewer for timeline
  */
-export const TimelineSlideViewer: React.FC<Props> = ({
+export const TimelineSlideViewer = ({
   children,
   scale,
   slideProps,
   template,
   onTemplateClick
-}) => {
+}: PropsWithChildren<Props>) => {
   const activeSlideId = useRootSelector(activeSlideIdSelector);
   const slideTemplateOpen = useRootSelector(slideTemplateOpenSelector);
   const dispatch = useDispatch();
@@ -109,7 +122,10 @@ export const TimelineSlideViewer: React.FC<Props> = ({
 
   // Move a local item as its dragged.
   const moveItem = React.useCallback(
-    ({ index: dragIndex }, { index: hoverIndex }) => {
+    (
+      { index: dragIndex }: ElementLocation,
+      { index: hoverIndex }: ElementLocation
+    ) => {
       setLocalSlides((items) => moveArrayItem(items, dragIndex, hoverIndex));
     },
     []

--- a/src/components/slide/slide.tsx
+++ b/src/components/slide/slide.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import styled, { css, InterpolationValue } from 'styled-components';
 import {
   background,
@@ -70,15 +70,17 @@ interface Props {
   padding?: number | string;
 }
 
-export const Slide: React.FC<Props> = ({
+export const Slide = ({
   id,
   children,
   scale,
   backgroundColor,
   textColor,
   padding,
-  slideProps = {}
-}) => {
+  slideProps = {
+    containerStyle: ''
+  }
+}: PropsWithChildren<Props>) => {
   const { containerStyle, handleKeyPress, onSlideClick, ...rest } = slideProps;
 
   return (

--- a/src/components/user-interface/accordion.tsx
+++ b/src/components/user-interface/accordion.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import styled from 'styled-components';
 import {
   ChevronDownIcon,
@@ -37,7 +37,7 @@ interface Props {
   label: string;
 }
 
-export const Accordion: React.FC<Props> = ({ children, label }) => {
+export const Accordion = ({ children, label }: PropsWithChildren<Props>) => {
   const [open, setIsOpen] = useState(true);
   return (
     <AccordionContainer>

--- a/src/components/user-interface/inline-editor/visual-editor-components/toolbar-button.tsx
+++ b/src/components/user-interface/inline-editor/visual-editor-components/toolbar-button.tsx
@@ -3,7 +3,7 @@ import { IconButton, Tooltip } from 'evergreen-ui';
 
 interface Props {
   tooltip: string;
-  icon: React.ElementType | JSX.Element;
+  icon?: React.ReactElement;
   onClick: () => void;
   isSelected: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,7 +4145,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.0":
+"@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.0", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -4358,24 +4358,17 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@>=16.9.0":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.2.tgz#35654cf6c49ae162d5bc90843d5437dc38008d43"
-  integrity sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==
+"@types/react-dom@>=16.9.0", "@types/react-dom@^18.0.5":
+  version "18.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
+  integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^18.0.4":
-  version "18.0.4"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.4.tgz#dcbcadb277bcf6c411ceff70069424c57797d375"
-  integrity sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-redux@^7.1.16":
-  version "7.1.16"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.16.tgz#0fbd04c2500c12105494c83d4a3e45c084e3cb21"
-  integrity sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==
+"@types/react-redux@^7.1.24":
+  version "7.1.24"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.24.tgz#6caaff1603aba17b27d20f8ad073e4c077e975c0"
+  integrity sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
@@ -4410,19 +4403,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.3":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
-  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16.9.5":
-  version "16.14.5"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.5.tgz#2c39b5cadefaf4829818f9219e5e093325979f4d"
-  integrity sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^16.9.5", "@types/react@^18.0.12":
+  version "18.0.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.12.tgz#cdaa209d0a542b3fcf69cf31a03976ec4cdd8840"
+  integrity sha512-duF1OTASSBQtcigUvhuiTB1Ya3OvSy+xORCiEf20H0P0lzx+/KeVsA99U5UjLXSbyo1DRJDlLKqTeM1ngosqtg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -4524,6 +4508,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/uuid@^8.3.0":
   version "8.3.0"
@@ -15703,6 +15692,11 @@ react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-is@^18.0.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
+  integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -15741,16 +15735,17 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-redux@^7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.2.tgz#03862e803a30b6b9ef8582dadcc810947f74b736"
-  integrity sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==
+react-redux@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.2.tgz#bc2a304bb21e79c6808e3e47c50fe1caf62f7aad"
+  integrity sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==
   dependencies:
     "@babel/runtime" "^7.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
     hoist-non-react-statics "^3.3.2"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-is "^16.13.1"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
 
 react-refresh@^0.8.3:
   version "0.8.3"
@@ -18759,6 +18754,11 @@ use-resize-observer@^6.1.0:
   integrity sha512-SiPcWHiIQ1CnHmb6PxbYtygqiZXR0U9dNkkbpX9VYnlstUwF8+QqpUTrzh13pjPwcjMVGR+QIC+nvF5ujfFNng==
   dependencies:
     resize-observer-polyfill "^1.5.1"
+
+use-sync-external-store@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
+  integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
I saw a number of type errors that were related to the upgrade to React 18 where `FC<T>` dropped `children` from the interface. This swaps that out with `PropsWithChildren<T>`