### PR TITLE
Fix/transparent persistant default color

### DIFF
--- a/src/constants/color-swatches.ts
+++ b/src/constants/color-swatches.ts
@@ -23,5 +23,5 @@ const THEME_COLORS_BY_TYPE = Object.values(
 // Flatten sorted object so that colors can be mapped over
 export const DEFAULT_COLORS = Object.values(THEME_COLORS_BY_TYPE).reduce(
   (allColors: string[], colorType: string[]) => [...allColors, ...colorType],
-  []
+  ['transparent']
 );


### PR DESCRIPTION
The first color in the list of default colors is now transparent:
<img width="240" alt="image" src="https://user-images.githubusercontent.com/17250443/175359279-d53a1830-90bc-45c3-af44-d98c12fe4fe6.png">

### Changes:
- [Narrowed type for THEME_COLORS_BY_TYPE](https://github.com/FormidableLabs/spectacle-visual-editor/commit/1a356d6e5b55177fb54c232b594e882a7da194d0)
- [Add transparent as default color to picker defaults](https://github.com/FormidableLabs/spectacle-visual-editor/commit/0defdaf407f5ef3ac9a74784e1e920d9c9164036)

closes: #184
