### PR TITLE
Adding transparent background for transparent color

### DIFF
--- a/src/components/inputs/color.tsx
+++ b/src/components/inputs/color.tsx
@@ -8,7 +8,7 @@ import { isValidCSSColor } from '../../util/is-valid-css-color';
 import { useRootSelector } from '../../store';
 import { themeSelector } from '../../slices/deck-slice';
 import { SWATCH_NAMES, DEFAULT_COLORS } from '../../constants/color-swatches';
-import TransSVG from './transparentSVG';
+import { TransSVG } from './transparentSVG';
 
 extend([namesPlugin]); // convert CSS colors to RGBA strings
 

--- a/src/components/inputs/transparentSVG.tsx
+++ b/src/components/inputs/transparentSVG.tsx
@@ -4,7 +4,7 @@ interface Props extends SVGProps<SVGSVGElement> {
   size?: number;
 }
 
-const TransSVG = ({ size = 18, ...props }: Props) => (
+export const TransSVG = ({ size = 18, ...props }: Props) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={size}
@@ -20,5 +20,3 @@ const TransSVG = ({ size = 18, ...props }: Props) => (
     />
   </svg>
 );
-
-export default TransSVG;


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Added background svg child to  swatch button if color is transparent

Fixes #191 

#### Type of Change
<!-- Please delete options that are not relevant (including this descriptive text). -->
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Tested manually clicking the swatch button under default swatches

### Screenshots (for visual changes):

<img width="228" alt="image" src="https://user-images.githubusercontent.com/17250443/175548922-affbb4c5-c162-40cc-9189-011519aebeea.png">
