### PR TITLE
Adding bundle analyzer stats script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "commonjs",
   "scripts": {
     "start": "netlify dev",
+    "stats": " STATS=server netlify dev",
     "dev": "webpack serve --mode=development --hot",
     "build": "webpack --mode=production",
     "prettier-check": "yarn prettier --check src/**",

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -1,6 +1,7 @@
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import webpack from 'webpack';
+import BundleAnalyzer from 'webpack-bundle-analyzer';
 
 const __dirname = path.resolve();
 
@@ -11,7 +12,7 @@ export default (env, argv) => {
     devtool: isDevelopment ? 'cheap-module-source-map' : false,
     output: {
       path: path.resolve(__dirname, 'build'),
-      filename: '[name].js',
+      filename: '[name].js'
     },
     resolve: {
       extensions: ['.tsx', '.ts', '.js'],
@@ -52,7 +53,7 @@ export default (env, argv) => {
         cacheGroups: {
           default: {
             minChunks: 2,
-            reuseExistingChunk: true,
+            reuseExistingChunk: true
           },
           vendor: {
             test(module) {
@@ -62,7 +63,9 @@ export default (env, argv) => {
               if (!module.context.includes('node_modules')) {
                 return false;
               }
-              return !['react-ace', 'ace-builds'].some(moduleContext => module.context.includes(moduleContext));
+              return !['react-ace', 'ace-builds'].some((moduleContext) =>
+                module.context.includes(moduleContext)
+              );
             },
             name: 'vendors',
             chunks: 'all'
@@ -71,6 +74,9 @@ export default (env, argv) => {
       }
     },
     plugins: [
+      new BundleAnalyzer.BundleAnalyzerPlugin({
+        analyzerMode: process.env.STATS || 'disabled'
+      }),
       new webpack.ProvidePlugin({
         process: 'process/browser.js'
       }),


### PR DESCRIPTION

### Description
This PR calls the bundle analyzer plugin with the `stats` script to more easily check bundle sizes in the future.


#### Type of Change
<!-- Please delete options that are not relevant (including this descriptive text). -->
- [x] New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Tested using stats script: `yarn stats`

### Screenshots (for visual changes):
![image](https://user-images.githubusercontent.com/17250443/176163936-31e41cc5-dc3f-4259-b9f1-daae59900c3e.png)
