### PR TITLE
fix: Resize handle focus

### DIFF
--- a/src/hooks/use-editor-actions.ts
+++ b/src/hooks/use-editor-actions.ts
@@ -7,17 +7,16 @@ export const useEditorActions = () => {
 
   const handleCanvasMouseDown = useCallback(
     (event: MouseEvent) => {
-      if (event.currentTarget.classList.contains('moveable-control')) {
+      const target = event?.target as Element;
+      if (target?.classList.contains('moveable-control')) {
         return;
-      } else if (!event.currentTarget.id) {
+      } else if (!target.id) {
         dispatch(deckSlice.actions.editableElementSelected(null));
         return;
       }
       event.preventDefault();
       event.stopPropagation();
-      dispatch(
-        deckSlice.actions.editableElementSelected(event.currentTarget.id)
-      );
+      dispatch(deckSlice.actions.editableElementSelected(target.id));
     },
     [dispatch]
   );


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Change use of currentTarget to target, meaning we change from looking at the dom node the event handler is attached on to the dom node that was click to trigger the event through bubbling. (I think :) ) 


Fixes #182 

#### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots (for visual changes):

Before:
<detail>

https://user-images.githubusercontent.com/17838632/176662939-5db577e9-3867-4703-9a83-f45196d657ad.mov

</detail>

After:
<detail>

https://user-images.githubusercontent.com/17838632/176662491-0d734feb-9a11-4b74-be7f-3c4b7374f1d1.mov

</detail>
