### PR TITLE
update color swatch styling

### DIFF
--- a/src/components/inputs/color.tsx
+++ b/src/components/inputs/color.tsx
@@ -12,6 +12,27 @@ import { TransSVG } from './transparentSVG';
 
 extend([namesPlugin]); // convert CSS colors to RGBA strings
 
+const ColorSwatchContainer = styled.div`
+  position: relative;
+  margin-left: 8px;
+  display: inline-block;
+  border: 1px solid #c1c4d6;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px white;
+  overflow: clip;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+
+  svg {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 32px;
+    width: 32px;
+  }
+`;
+
 export const Container = styled.div<{ isDisabled: boolean }>`
   display: flex;
   flex-direction: row;
@@ -22,18 +43,18 @@ export const Container = styled.div<{ isDisabled: boolean }>`
   div {
     flex: 1;
   }
+
+  ${ColorSwatchContainer} {
+    flex: initial;
+  }
 `;
 
 const ColorSwatch = styled.span`
-  display: inline-block;
-  border: 1px solid hsla(0, 0%, 0%, 0.5);
-  border-radius: 24px;
-  margin-left: 8px;
-  margin-bottom: 3px;
-  box-shadow: inset 0 0 0 1px white;
+  display: block;
+  height: 32px;
+  width: 32px;
   background: ${({ color }) => color};
-  width: 24px;
-  height: 24px;
+  position: absolute;
 `;
 
 export const PopoverContainer = styled.div`
@@ -195,7 +216,10 @@ export const ColorPickerInput: React.FC<Props> = ({
             onUpdateValue(updatedValue);
           }}
         />
-        <ColorSwatch color={validValue || ''} />
+        <ColorSwatchContainer>
+          <TransSVG />
+          <ColorSwatch color={validValue || ''} />
+        </ColorSwatchContainer>
       </Container>
     </Popover>
   );


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/spectacle/blob/main/CONTRIBUTING.md#contributor-covenant-code-of-conduct

-->

### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Matches the the color swatch picker to the normal text input styling.

Fixes #194  (issue)

#### Type of Change
<!-- Please delete options that are not relevant (including this descriptive text). -->

- [X] Bug fix 

### How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My code follows the style guidelines of this project (I have run `yarn prettier-fix`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Screenshots (for visual changes):

Swatch inputs are now rounded squares that matches height with text inputs:

<img width="325" alt="image" src="https://user-images.githubusercontent.com/33091572/179618141-67d74f7f-62d8-4e21-be96-5aff96f24b74.png">

Colors with transparency will show a checker pattern underneath:

<img width="297" alt="image" src="https://user-images.githubusercontent.com/33091572/179618172-d0c88e21-400d-4b1a-b6c9-78c89bae7ae6.png">
<img width="295" alt="image" src="https://user-images.githubusercontent.com/33091572/179618317-e12d1ae2-8021-49f5-82db-829359d5a438.png">

