### PR TITLE
build: resolve tsconfig error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,
     "moduleResolution": "Node",                  /* Do not emit comments to output. */
-    "noEmit": false /* Do not emit outputs. */,
+    "noEmit": true                                  /* Do not emit outputs. */,
     // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */


### PR DESCRIPTION
### Description

The tsconfig was set up to emit outputs, but not exclude the directory containing those outputs from future compilation, so it was giving off compiler errors in the editor. This could also be solved by changing the `outDir` to "./build", but it was not immediately apparent what use a standalone app had for emitted TypeScript types, so I just turned on `noEmit`.

![image](https://user-images.githubusercontent.com/4413963/186223000-aea5ee88-faeb-4e5a-b671-78c0bd185161.png)

See also: https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file


#### Type of Change
<!-- Please delete options that are not relevant (including this descriptive text). -->

Internal fix.

### How Has This Been Tested?

I ran the `pnpm dev` and `pnpm build` commands, and they ran without issue.