### PR TITLE
Fix slide scaling and scrolling

### DIFF
--- a/src/components/user-interface/editor-styles.ts
+++ b/src/components/user-interface/editor-styles.ts
@@ -24,10 +24,8 @@ export const EditorCanvas = styled.div<{ scale: string }>`
   flex: 1;
   align-items: ${(props) => (props.scale === 'fit' ? 'center' : 'flex-start')};
   justify-content: center;
-  overflow: auto;
 
   ${SlideScaleWrapper} {
     box-shadow: ${defaultTheme.shadows[2]};
-    overflow: auto;
   }
 `;

--- a/src/components/user-interface/editor-styles.ts
+++ b/src/components/user-interface/editor-styles.ts
@@ -28,6 +28,6 @@ export const EditorCanvas = styled.div<{ scale: string }>`
 
   ${SlideScaleWrapper} {
     box-shadow: ${defaultTheme.shadows[2]};
-    overflow: scroll;
+    overflow: auto;
   }
 `;

--- a/src/components/user-interface/editor-styles.ts
+++ b/src/components/user-interface/editor-styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { SlideScaleWrapper } from '../slide/slide';
 import { defaultTheme } from 'evergreen-ui';
+import { SettingsState } from '../../slices/settings-slice';
 
 export const EditorBody = styled.div`
   background: ${defaultTheme.colors.gray300};
@@ -19,7 +20,7 @@ export const EditorContent = styled.div`
   flex-direction: row;
 `;
 
-export const EditorCanvas = styled.div<{ scale: string }>`
+export const EditorCanvas = styled.div<{ scale: SettingsState['scale'] }>`
   display: flex;
   flex: 1;
   align-items: ${(props) => (props.scale === 'fit' ? 'center' : 'flex-start')};

--- a/src/components/user-interface/menu-bar.tsx
+++ b/src/components/user-interface/menu-bar.tsx
@@ -437,7 +437,7 @@ export const MenuBar = () => {
                 title="Preview Size"
                 options={[
                   { label: 'To fit', value: 'fit' },
-                  { label: 'Actual size', value: '1' }
+                  { label: 'Actual size', value: 1 }
                 ]}
                 selected={scale}
                 onChange={(selected) => {

--- a/src/hooks/use-slide-scale.ts
+++ b/src/hooks/use-slide-scale.ts
@@ -1,15 +1,15 @@
 import { useEffect, useState, useRef, useCallback, RefObject } from 'react';
 import { useSelector } from 'react-redux';
 import { themeSelector } from '../slices/deck-slice';
-import { settingsSelector } from '../slices/settings-slice';
+import { settingsSelector, SettingsState } from '../slices/settings-slice';
 import { SpectacleTheme } from '../types/theme';
 
 function getScale(
   canvasEl: HTMLDivElement,
   size: SpectacleTheme['size'],
-  scaleSetting: string
-) {
-  if (scaleSetting !== 'fit') return Number(scaleSetting);
+  scaleSetting: SettingsState['scale']
+): number {
+  if (scaleSetting !== 'fit') return scaleSetting;
 
   // We use the parent element here as a stable reference for the
   // constrained area we have to show the canvas element in. The canvas element

--- a/src/slices/settings-slice.ts
+++ b/src/slices/settings-slice.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { RootState } from '../store';
 
-type SettingsState = {
-  scale: string;
+export type SettingsState = {
+  scale: 'fit' | number;
 };
 
 const initialState: SettingsState = {

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -23,7 +23,7 @@ export default (env, argv) => {
       rules: [
         {
           test: /\.tsx?$/,
-          use: 'ts-loader',
+          use: ['babel-loader', 'ts-loader'],
           exclude: /node_modules/
         },
         {


### PR DESCRIPTION
### Description

There were a few issues around scrolling and scaling resolved by this PR.

From the following video, in order of appearance:

1. Scrollbars are shown around the slide even when the zoom mode is set to "Fit"
2. In "Fit" mode, resizing the panes does not result in the slide view getting resized
3. When a horizontal scrollbar is needed, as in the "Actual Size" zoom mode, it is shown nested within a different scrollable element, so it is hidden unless we scroll down.
4. There was a perpetually unused region dedicated to showing a scrollbar, due to `overflow: scroll`.


https://user-images.githubusercontent.com/4413963/187970962-62b0bbe4-fbbf-4e2f-9580-4d88e6a11369.mov



#### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually

### Screenshots (for visual changes):

https://user-images.githubusercontent.com/4413963/187971998-b918edc9-8e2c-4c85-9ecd-b86871129ef5.mov

